### PR TITLE
Metrics2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.61])
-AC_INIT([kvAgregated], [2.4.4~rc1], [kvoss@met.no])
+AC_INIT([kvAgregated], [2.4.4], [kvoss@met.no])
 
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.61])
-AC_INIT([kvAgregated], [2.4.3], [kvoss@met.no])
+AC_INIT([kvAgregated], [2.4.4~rc1], [kvoss@met.no])
 
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/debian_files/changelog
+++ b/debian_files/changelog
@@ -1,3 +1,9 @@
+kvagregated (2.4.4~rc1-1) UNRELEASED; urgency=medium
+  * Add metrics for database access.
+  * Add metric for total duration.
+
+ -- Vegard Bones <vegard.bones@met.no>  Fri, 12 Jun 2020 10:00:00 +0200
+
 kvagregated (2.4.3-1) UNRELEASED; urgency=medium
   * New release.
 

--- a/debian_files/changelog
+++ b/debian_files/changelog
@@ -1,3 +1,8 @@
+kvagregated (2.4.4-1) UNRELEASED; urgency=medium
+  * Add metrics.
+
+ -- Vegard Bones <vegard.bones@met.no>  Mon, 15 Jun 2020 8:30:00 +0200
+
 kvagregated (2.4.4~rc1-1) UNRELEASED; urgency=medium
   * Add metrics for database access.
   * Add metric for total duration.

--- a/src/LogAppender.cpp
+++ b/src/LogAppender.cpp
@@ -1,0 +1,141 @@
+/*
+ Kvalobs - Free Quality Control Software for Meteorological Observations
+
+ $Id: kvPath.h,v 1.1.2.2 2007/09/27 09:02:30 paule Exp $
+
+ Copyright (C) 2007 met.no
+
+ Contact information:
+ Norwegian Meteorological Institute
+ Box 43 Blindern
+ 0313 OSLO
+ NORWAY
+ email: kvalobs-dev@met.no
+
+ This file is part of KVALOBS
+
+ KVALOBS is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License as
+ published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ KVALOBS is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with KVALOBS; if not, write to the Free Software Foundation Inc.,
+ 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <boost/filesystem.hpp>
+#include "LogAppender.h"
+#include <kvalobs/kvPath.h>
+#include <milog/milog.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+
+namespace fs = boost::filesystem;
+
+
+namespace {
+int openFile(const std::string &file, std::string *err) {
+  int fd = open(file.c_str(), O_WRONLY|O_APPEND|O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
+  if (fd < 0) {
+    const int BUF_SIZE = 512;
+    char msg[BUF_SIZE];
+    strerror_r(errno, msg, BUF_SIZE);
+    msg[BUF_SIZE-1]='\0';
+    std::ostringstream o;
+    o << "Faile to creat or open log file '" << file << "'. " << msg;
+    *err = o.str();
+    LOGWARN("Error when creating/open log file '" << file << "'. " << msg);
+    return -1;
+  } 
+
+  return fd;
+}
+
+std::string timestamp() {
+  struct tm stm;
+  auto now=std::chrono::system_clock::now();
+  std::time_t t = std::chrono::system_clock::to_time_t(now);
+  gmtime_r(&t, &stm);
+  char timeString[256];
+  std::strftime(timeString, 256, "%FT%T", &stm);
+  return timeString;
+}
+
+
+
+}
+
+
+
+namespace miutil {
+
+
+LogAppender::LogAppender(const std::string &logfile, const std::string &dir):ok_(true)
+{
+  fs::path path(logfile);
+
+  if( path.is_relative() ) {
+    fs::path d(dir);
+    path=d/path;
+  }
+
+  logfile_=path.string();
+
+  fs::path d=path.parent_path();
+  try {
+    if( !d.empty() )
+     fs::create_directories(d);
+
+    std::string err;
+    if( openFile(logfile_, &err) < 0 ) {
+      ok_=false;
+      LOGERROR("LogAppender: Failed to open/create logfile '" << logfile_ << "'. " << err);
+    } 
+  }
+  catch( const std::exception &e){
+    std::ostringstream o;
+    o << "Failed to create directory '" << d << "'. " << e.what();
+    lastError_=o.str();
+    ok_=false;
+  }
+}
+    
+LogAppender::~LogAppender(){  
+}
+
+bool LogAppender::log(const std::string &message)  {
+  if( message.empty() )
+    return true;
+
+  int fd = openFile(logfile_, &lastError_);
+
+  if ( fd < 0 ) {
+    return false;
+  }
+
+  std::ostringstream o;
+  o << timestamp() <<": " << message;
+  
+  if( *message.rend() != '\n')
+    o << "\n";
+
+  auto m = o.str(); 
+
+  write(fd, m.c_str(), m.size());
+  close(fd);
+  return true;
+}
+
+}

--- a/src/LogAppender.h
+++ b/src/LogAppender.h
@@ -1,0 +1,71 @@
+/*
+ Kvalobs - Free Quality Control Software for Meteorological Observations
+
+ $Id: kvPath.h,v 1.1.2.2 2007/09/27 09:02:30 paule Exp $
+
+ Copyright (C) 2007 met.no
+
+ Contact information:
+ Norwegian Meteorological Institute
+ Box 43 Blindern
+ 0313 OSLO
+ NORWAY
+ email: kvalobs-dev@met.no
+
+ This file is part of KVALOBS
+
+ KVALOBS is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License as
+ published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ KVALOBS is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with KVALOBS; if not, write to the Free Software Foundation Inc.,
+ 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef SRC_MIUTIL_LOGAPPENDER_H_
+#define SRC_MIUTIL_LOGAPPENDER_H_
+
+#include <string>
+
+namespace miutil {
+
+/**
+ * Simple logger that apends to a file atomical. Log rotation is expected to be handled
+ * elsewhere (in debian package).
+ *
+ */
+class LogAppender {
+ public:
+ LogAppender(): ok_(false) {}
+  explicit LogAppender(const std::string &logFile, const std::string &dir=".");
+  ~LogAppender();
+
+  bool isOk()const {return ok_;}
+  std::string lastError()const { return lastError_;}
+  /**
+   * Log the message to the logfile.
+   * @return true if logged and false otherwise. Check lastError.
+   */
+  bool log(const std::string &message);
+
+  /**
+   * Get the name of the file to log to.
+   */
+  std::string logFile() { return logfile_;}
+
+ private:
+  bool ok_;
+  std::string lastError_;
+  std::string logfile_;
+};
+
+}  
+
+#endif  

--- a/src/kvAgregated.mk
+++ b/src/kvAgregated.mk
@@ -11,6 +11,10 @@ kvAgregated_SOURCES = \
 	src/BackProduction.cc \
 	src/paramID.h \
 	src/times.h \
+	src/metrics.h \
+	src/metrics.cc \
+	src/LogAppender.h \
+	src/LogAppender.cpp \
 	src/main.cc
 
 AM_CPPFLAGS = \

--- a/src/main.cc
+++ b/src/main.cc
@@ -28,6 +28,7 @@
  51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 #include <kvcpp/KvApp.h>
+#include <kvalobs/kvPath.h>
 #include "AggregatorRunner.h"
 #include "AggregatorHandler.h"
 #include "BackProduction.h"
@@ -60,6 +61,7 @@
 #include "aggregator/po.h"
 #include "aggregator/ot_24.h"
 #include <memory>
+#include "metrics.h"
 
 using namespace std;
 using namespace aggregator;
@@ -165,8 +167,10 @@ int main(int argc, char **argv)
 	AggregatorConfiguration conf;
 	AggregatorConfiguration::ParseResult result = conf.parse(argc, argv);
 
+
 	if (result != AggregatorConfiguration::No_Action)
 		return result;
+
 
 
 	try
@@ -180,8 +184,10 @@ int main(int argc, char **argv)
 		{
 			// PidFile
 			dnmi::file::PidFileHelper pidFile;
-			if (conf.runInDaemonMode())
+			if (conf.runInDaemonMode()) {
 				setupPidFile(pidFile);
+				setMetricsLogfile("kvAgregated_metrics.log", kvalobs::kvPath(kvalobs::logdir));
+			}
 
 			// KvApp
 			std::unique_ptr<kvservice::KvApp> app(kvservice::KvApp::create("kvaggregated", argc, argv));

--- a/src/main.cc
+++ b/src/main.cc
@@ -29,6 +29,7 @@
  */
 #include <kvcpp/KvApp.h>
 #include <kvalobs/kvPath.h>
+#include <decodeutility/kvalobsdataserializer.h>
 #include "AggregatorRunner.h"
 #include "AggregatorHandler.h"
 #include "BackProduction.h"
@@ -164,14 +165,12 @@ void runAgregator(const AggregatorConfiguration & conf,
 
 int main(int argc, char **argv)
 {
+	kvalobs::serialize::KvalobsDataSerializer::defaultProducer="kvAgregated";
 	AggregatorConfiguration conf;
 	AggregatorConfiguration::ParseResult result = conf.parse(argc, argv);
 
-
 	if (result != AggregatorConfiguration::No_Action)
 		return result;
-
-
 
 	try
 	{

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -77,9 +77,19 @@ bool setMetricsLogfile( const std::string &logfile, const std::string &dir ) {
 void logMetrics(std::shared_ptr<Metrics> metrics, const boost::posix_time::ptime &obstime, int stationid, int typeId) {
   if( logAppender.isOk() ) {
     std::ostringstream o;
+    std::string status=metrics->sendtToKvalobs()>0?"true":"false";
+
+    //This check for empty messages sendt to kvalobs.
+    //This is seen sometimes.
+    if(metrics->sendtToKvalobs()<0) {
+      status ="empty";
+    } 
+    
     o << " (" << stationid << "/" << typeId << "/" << boost::posix_time::to_kvalobs_string(obstime) <<")"
-      << " cachedb: " << metrics->cacheDb.acc().count() << " ms kvdb: " << metrics->kvDb.acc().count() << " ms duration: "
-    << metrics->timeToCompletion().count() << " ms\n";
+      << " sendtToKv: " << status  
+      << " cachedb: " << metrics->cacheDb.acc().count() << " ms kvdb: " 
+      << metrics->kvDb.acc().count() << " ms duration: "
+    << metrics->timeToCompletion().count() << " ms";
     logAppender.log( o.str());
   }
 }
@@ -116,5 +126,5 @@ Metrics::timeToCompletion() const
 }
 
 Metrics::Metrics()
-  : startTime_(high_resolution_clock::now())
+  : sendtToKvalobs_(0), startTime_(high_resolution_clock::now())
 {}

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -1,0 +1,120 @@
+/*
+  Kvalobs - Free Quality Control Software for Meteorological Observations
+
+  $Id: paramID.h,v 1.1.2.5 2007/09/27 09:02:16 paule Exp $
+
+  Copyright (C) 2007 met.no
+
+  Contact information:
+  Norwegian Meteorological Institute
+  Box 43 Blindern
+  0313 OSLO
+  NORWAY
+  email: kvalobs-dev@met.no
+
+  This file is part of KVALOBS
+
+  KVALOBS is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License as
+  published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  KVALOBS is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with KVALOBS; if not, write to the Free Software Foundation Inc.,
+  51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "metrics.h"
+#include "LogAppender.h"
+#include <milog/milog.h>
+#include <miutil/timeconvert.h>
+#include <sstream>
+
+using namespace std::chrono;
+
+namespace {
+thread_local std::shared_ptr<Metrics> metrics;
+miutil::LogAppender logAppender;
+}
+
+std::shared_ptr<Metrics>
+getMetrics()
+{
+  if (!metrics) {
+    metrics = std::shared_ptr<Metrics>(new Metrics());
+  }
+  return metrics;
+}
+
+void
+setMetrics(std::shared_ptr<Metrics> m)
+{
+  metrics = m;
+}
+
+
+//Set the logfile to use for metrics.
+//The log file must be rotate by some external ways. ex logrotate.
+bool setMetricsLogfile( const std::string &logfile, const std::string &dir ) {
+  if(  logfile.empty() )
+    return false;
+  
+  logAppender=miutil::LogAppender(logfile, dir); 
+
+  if( logAppender.isOk() ) {
+    LOGINFO("Writing metrics to: '" << logAppender.logFile() << "'.");
+  }
+
+  return logAppender.isOk();
+}
+
+//Log the metrics to the logfile.
+void logMetrics(std::shared_ptr<Metrics> metrics, const boost::posix_time::ptime &obstime, int stationid, int typeId) {
+  if( logAppender.isOk() ) {
+    std::ostringstream o;
+    o << " (" << stationid << "/" << typeId << "/" << boost::posix_time::to_kvalobs_string(obstime) <<")"
+      << " cachedb: " << metrics->cacheDb.acc().count() << " ms kvdb: " << metrics->kvDb.acc().count() << " ms duration: "
+    << metrics->timeToCompletion().count() << " ms\n";
+    logAppender.log( o.str());
+  }
+}
+
+
+
+using namespace std::chrono;
+
+Metric::Metric()
+  : timer_(high_resolution_clock::now())
+  , acc_(0)
+{}
+
+void
+Metric::start()
+{
+  timer_ = high_resolution_clock::now();
+}
+
+Metric::MilliDuration
+Metric::stop(bool accumulate)
+{
+  auto d = duration_cast<milliseconds>(high_resolution_clock::now() - timer_);
+  if (accumulate) {
+    acc_ += d;
+  }
+  return d;
+}
+
+Metric::MilliDuration
+Metrics::timeToCompletion() const
+{
+  return duration_cast<milliseconds>(high_resolution_clock::now() - startTime_);
+}
+
+Metrics::Metrics()
+  : startTime_(high_resolution_clock::now())
+{}

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -77,7 +77,7 @@ bool setMetricsLogfile( const std::string &logfile, const std::string &dir ) {
 void logMetrics(std::shared_ptr<Metrics> metrics, const boost::posix_time::ptime &obstime, int stationid, int typeId) {
   if( logAppender.isOk() ) {
     std::ostringstream o;
-    std::string status=metrics->sendtToKvalobs()>0?"true":"false";
+    std::string status=metrics->sendtToKvalobs()?"true":"false";
 
     //This check for empty messages sendt to kvalobs.
     //This is seen sometimes.
@@ -126,5 +126,5 @@ Metrics::timeToCompletion() const
 }
 
 Metrics::Metrics()
-  : sendtToKvalobs_(0), startTime_(high_resolution_clock::now())
+  : sendtToKvalobs_(false), startTime_(high_resolution_clock::now())
 {}

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -58,15 +58,26 @@ class Metrics {
   public:
     Metrics();
 
+    //Measure the total performance of the sqlite3 access. 
+    //One observation 
     Metric cacheDb;
+
+    //Measure the total performance for comunication with kvalobs.
+    //One observation.
     Metric kvDb;
 
-    int sendtToKvalobs(int isSendt) { sendtToKvalobs_=isSendt;}
+
+    //For the observation. Did it trigger an generation of a 
+    //aggregated value to be sendt to kvalobs.
+    void sendtToKvalobs(bool isSendt) { sendtToKvalobs_=isSendt;}
     bool sendtToKvalobs()const{ return sendtToKvalobs_;}
 
+    //The total duration used from the start of computation to the
+    //compution is finished. This include the metrics for cacheDb and
+    //kvDb. The computation is triggered by the receipt of an observation.
     Metric::MilliDuration timeToCompletion() const;
   private: 
-    int sendtToKvalobs_;
+    bool sendtToKvalobs_;
     Metric::TimeType startTime_;
 };
 

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -1,0 +1,84 @@
+/*
+  Kvalobs - Free Quality Control Software for Meteorological Observations 
+
+  $Id: paramID.h,v 1.1.2.5 2007/09/27 09:02:16 paule Exp $                                                       
+
+  Copyright (C) 2007 met.no
+
+  Contact information:
+  Norwegian Meteorological Institute
+  Box 43 Blindern
+  0313 OSLO
+  NORWAY
+  email: kvalobs-dev@met.no
+
+  This file is part of KVALOBS
+
+  KVALOBS is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License as 
+  published by the Free Software Foundation; either version 2 
+  of the License, or (at your option) any later version.
+  
+  KVALOBS is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+  
+  You should have received a copy of the GNU General Public License along 
+  with KVALOBS; if not, write to the Free Software Foundation Inc., 
+  51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#ifndef __agregator_Metrics_h__
+#define __agregator_Metrics_h__
+
+#include <memory>
+#include <chrono>
+#include <boost/date_time/posix_time/ptime.hpp>
+
+class Metric {
+  public:
+    typedef std::chrono::time_point<std::chrono::high_resolution_clock> TimeType; 
+    typedef std::chrono::duration<int,std::milli> MilliDuration;
+
+    Metric();
+
+    void start();
+    //Return the duration
+    MilliDuration stop(bool accmulate=true);
+    MilliDuration acc() const { return acc_;}
+        
+  private:
+    TimeType timer_;
+    MilliDuration acc_;
+};
+
+
+
+class Metrics {
+  public:
+    Metrics();
+
+
+
+    Metric cacheDb;
+    Metric kvDb;
+
+    Metric::MilliDuration timeToCompletion() const;
+  private: 
+    Metric::TimeType startTime_;
+};
+
+
+//Manage thread local storage for metrics.
+std::shared_ptr<Metrics> getMetrics();
+void setMetrics( std::shared_ptr<Metrics> m);
+
+//Set the logfile to use for metrics.
+//The log file must be rotate by some external ways. ex logrotate.
+bool setMetricsLogfile( const std::string &logfile, const std::string &dir);
+
+//Log the metrics to the logfile.
+void logMetrics(std::shared_ptr<Metrics> metrics, const boost::posix_time::ptime &obstime, int stationid, int typeId);
+
+
+#endif

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -58,13 +58,15 @@ class Metrics {
   public:
     Metrics();
 
-
-
     Metric cacheDb;
     Metric kvDb;
 
+    int sendtToKvalobs(int isSendt) { sendtToKvalobs_=isSendt;}
+    bool sendtToKvalobs()const{ return sendtToKvalobs_;}
+
     Metric::MilliDuration timeToCompletion() const;
   private: 
+    int sendtToKvalobs_;
     Metric::TimeType startTime_;
 };
 

--- a/src/proxy/IncomingHandler.cc
+++ b/src/proxy/IncomingHandler.cc
@@ -164,27 +164,32 @@ IncomingHandler::isStopping() const
 void
 IncomingHandler::process(KvObsDataListPtr& data)
 {
-	
+
   if (not data->empty()) {
-		auto metrics =std::shared_ptr<Metrics>(new Metrics());
-		setMetrics(metrics);
     ostringstream ss;
+    
     ss << "Data in:" << endl;
-    for (IKvObsDataList i1 = data->begin(); i1 != data->end(); ++i1)
+    for (IKvObsDataList i1 = data->begin(); i1 != data->end(); ++i1) {
       for (CIKvDataList i2 = i1->dataList().begin(); i2 != i1->dataList().end();
-           ++i2)
+           ++i2) {
         ss << decodeutility::kvdataformatter::createString(*i2) << endl;
+      }
+    }
+
     LOGDEBUG(ss.str());
 
-    for (IKvObsDataList it = data->begin(); it != data->end(); ++it)
+    auto metrics =std::shared_ptr<Metrics>(new Metrics());
+		setMetrics(metrics);
+
+    for (IKvObsDataList it = data->begin(); it != data->end(); ++it) {
       dataAccess.cacheData(*it);
+    }
 
     callbacks_.send(*data);
-		auto d = data->front().dataList().front();
-		logMetrics(metrics, d.obstime(), d.stationID(), d.typeID());
+    auto d = data->front().dataList().front();
+    logMetrics(metrics, d.obstime(), d.stationID(), d.typeID());
 
-    LOGDEBUG("Station " << d.stationID()
-                        << " done");
+    LOGDEBUG("Station " << d.stationID() << " done");
   }
 }
 }

--- a/src/proxy/IncomingHandler.cc
+++ b/src/proxy/IncomingHandler.cc
@@ -30,10 +30,10 @@
  */
 #include "IncomingHandler.h"
 #include "Callback.h"
+#include "metrics.h"
+#include <boost/thread/thread.hpp>
 #include <decodeutility/kvDataFormatter.h>
 #include <milog/milog.h>
-
-#include <boost/thread/thread.hpp>
 
 #include <sstream>
 
@@ -43,144 +43,149 @@
 using namespace std;
 using namespace milog;
 
-namespace kvservice
+namespace kvservice {
+namespace proxy {
+namespace internal {
+IncomingHandler::HandlerThread::HandlerThread(IncomingHandler& handler)
+  : handler(handler)
+{}
+
+void
+IncomingHandler::HandlerThread::operator()()
 {
-namespace proxy
-{
-namespace internal
-{
-IncomingHandler::HandlerThread::HandlerThread(IncomingHandler & handler) :
-	handler(handler)
-{
+  LogContext context("Incoming");
+
+  while (1) {
+    KvObsDataListPtr data;
+    {
+      boost::mutex::scoped_lock lock(handler.mutex);
+
+      //            LOGDEBUG( "Top of loop: " << handler.queue.size()
+      //                      << " elements in queue." << endl );
+
+      if (not handler.isStopping() and handler.queue.empty()) {
+        // LOGDEBUG( "Thread sleeping" );
+        handler.condition.wait(lock);
+        // LOGDEBUG( "Thread woke up" );
+      }
+
+      if (handler.isStopping())
+        break;
+
+      if (handler.queue.empty()) {
+        LOGWARN("Wakeup on empty queue.");
+        continue;
+      }
+
+      data = handler.queue.front();
+      handler.queue.pop_front();
+    }
+
+    try {
+      handler.process(data);
+    } catch (std::exception& e) {
+      boost::mutex::scoped_lock lock(handler.mutex);
+      LOGERROR("Error when processing data. (Putting data back in queue): "
+               << e.what());
+      handler.queue.push_front(data);
+      handler.condition.notify_one();
+    }
+  }
+  // LOGDEBUG( "Thread terminating" );
 }
 
-void IncomingHandler::HandlerThread::operator()()
+IncomingHandler::IncomingHandler(DataAccess& dataAccess_,
+                                 CallbackCollection& callbacks,
+                                 bool doStartThreads,
+                                 int noOfThreads_)
+  : dataAccess(dataAccess_)
+  , callbacks_(callbacks)
+  , noOfThreads(noOfThreads_)
+  , threadsStopping(true)
 {
-	LogContext context("Incoming");
-
-	while (1)
-	{
-		KvObsDataListPtr data;
-		{
-			boost::mutex::scoped_lock lock(handler.mutex);
-
-			//            LOGDEBUG( "Top of loop: " << handler.queue.size()
-			//                      << " elements in queue." << endl );
-
-			if (not handler.isStopping() and handler.queue.empty())
-			{
-				//LOGDEBUG( "Thread sleeping" );
-				handler.condition.wait(lock);
-				//LOGDEBUG( "Thread woke up" );
-			}
-
-			if (handler.isStopping())
-				break;
-
-			if (handler.queue.empty())
-			{
-				LOGWARN( "Wakeup on empty queue." );
-				continue;
-			}
-
-			data = handler.queue.front();
-			handler.queue.pop_front();
-		}
-
-		try
-		{
-			handler.process(data);
-		} catch (std::exception & e)
-		{
-			boost::mutex::scoped_lock lock(handler.mutex);
-			LOGERROR( "Error when processing data. (Putting data back in queue): " << e.what() );
-			handler.queue.push_front(data);
-			handler.condition.notify_one();
-		}
-	}
-	//LOGDEBUG( "Thread terminating" );
-}
-
-IncomingHandler::IncomingHandler(DataAccess &dataAccess_,
-		CallbackCollection & callbacks, bool doStartThreads, int noOfThreads_) :
-	dataAccess(dataAccess_), callbacks_(callbacks), noOfThreads(noOfThreads_),
-			threadsStopping(true)
-{
-	if (doStartThreads)
-		startThreads();
+  if (doStartThreads)
+    startThreads();
 }
 
 IncomingHandler::~IncomingHandler()
 {
-	//assert( proxy.stopping() );
-	{
-		boost::mutex::scoped_lock lock(mutex);
-		queue.clear();
-	}
-	stopThreads();
+  // assert( proxy.stopping() );
+  {
+    boost::mutex::scoped_lock lock(mutex);
+    queue.clear();
+  }
+  stopThreads();
 }
 
-void IncomingHandler::onKvDataEvent(KvObsDataListPtr data)
+void
+IncomingHandler::onKvDataEvent(KvObsDataListPtr data)
 {
-	boost::mutex::scoped_lock lock(mutex);
-	queue.push_back(data);
-	condition.notify_one();
-	//process( data );
+  boost::mutex::scoped_lock lock(mutex);
+  queue.push_back(data);
+  condition.notify_one();
+  // process( data );
 }
 
-void IncomingHandler::startThreads()
+void
+IncomingHandler::startThreads()
 {
-	if (!threadsStopping)
-		throw ThreadRestart();
-	threadsStopping = false;
-	for (int i = 0; i < noOfThreads; ++i)
-	{
-		HandlerThread ht(*this);
-		boost::thread * thread = new boost::thread(ht);
-		threads.push_back(thread);
-	}
+  if (!threadsStopping)
+    throw ThreadRestart();
+  threadsStopping = false;
+  for (int i = 0; i < noOfThreads; ++i) {
+    HandlerThread ht(*this);
+    boost::thread* thread = new boost::thread(ht);
+    threads.push_back(thread);
+  }
 }
 
-void IncomingHandler::stopThreads()
+void
+IncomingHandler::stopThreads()
 {
-	threadsStopping = true;
+  threadsStopping = true;
 
-	condition.notify_all();
+  condition.notify_all();
 
-	for (list<boost::thread *>::iterator it = threads.begin(); it
-			!= threads.end(); ++it)
-	{
-		boost::thread * t = *it;
-		t->join();
-		delete t;
-	}
-	threads.clear();
+  for (list<boost::thread*>::iterator it = threads.begin(); it != threads.end();
+       ++it) {
+    boost::thread* t = *it;
+    t->join();
+    delete t;
+  }
+  threads.clear();
 }
 
-bool IncomingHandler::isStopping() const
+bool
+IncomingHandler::isStopping() const
 {
-	return threadsStopping;
+  return threadsStopping;
 }
 
-void IncomingHandler::process(KvObsDataListPtr & data)
+void
+IncomingHandler::process(KvObsDataListPtr& data)
 {
-	if (not data->empty())
-	{
-		ostringstream ss;
-		ss << "Data in:" << endl;
-		for (IKvObsDataList i1 = data->begin(); i1 != data->end(); ++i1)
-			for (CIKvDataList i2 = i1->dataList().begin(); i2
-					!= i1->dataList().end(); ++i2)
-				ss << decodeutility::kvdataformatter::createString(*i2) << endl;
-		LOGDEBUG( ss.str() );
+	
+  if (not data->empty()) {
+		auto metrics =std::shared_ptr<Metrics>(new Metrics());
+		setMetrics(metrics);
+    ostringstream ss;
+    ss << "Data in:" << endl;
+    for (IKvObsDataList i1 = data->begin(); i1 != data->end(); ++i1)
+      for (CIKvDataList i2 = i1->dataList().begin(); i2 != i1->dataList().end();
+           ++i2)
+        ss << decodeutility::kvdataformatter::createString(*i2) << endl;
+    LOGDEBUG(ss.str());
 
-		for (IKvObsDataList it = data->begin(); it != data->end(); ++it)
-			dataAccess.cacheData(*it);
+    for (IKvObsDataList it = data->begin(); it != data->end(); ++it)
+      dataAccess.cacheData(*it);
 
-		callbacks_.send(*data);
+    callbacks_.send(*data);
+		auto d = data->front().dataList().front();
+		logMetrics(metrics, d.obstime(), d.stationID(), d.typeID());
 
-		LOGDEBUG( "Station " << data->front().dataList().front().stationID() << " done" );
-	}
+    LOGDEBUG("Station " << d.stationID()
+                        << " done");
+  }
 }
 }
 }

--- a/src/proxy/IncomingHandler.cc
+++ b/src/proxy/IncomingHandler.cc
@@ -167,7 +167,7 @@ IncomingHandler::process(KvObsDataListPtr& data)
 
   if (not data->empty()) {
     ostringstream ss;
-    
+
     ss << "Data in:" << endl;
     for (IKvObsDataList i1 = data->begin(); i1 != data->end(); ++i1) {
       for (CIKvDataList i2 = i1->dataList().begin(); i2 != i1->dataList().end();
@@ -178,8 +178,8 @@ IncomingHandler::process(KvObsDataListPtr& data)
 
     LOGDEBUG(ss.str());
 
-    auto metrics =std::shared_ptr<Metrics>(new Metrics());
-		setMetrics(metrics);
+    auto metrics = std::shared_ptr<Metrics>(new Metrics());
+    setMetrics(metrics);
 
     for (IKvObsDataList it = data->begin(); it != data->end(); ++it) {
       dataAccess.cacheData(*it);

--- a/src/proxy/KvalobsDataAccess.cpp
+++ b/src/proxy/KvalobsDataAccess.cpp
@@ -113,6 +113,14 @@ CKvalObs::CDataSource::Result_var KvalobsDataAccess::sendData(const KvDataList &
 		throw std::runtime_error("No kvalobs connection");
 
 	auto metrics=getMetrics();
+	
+	if( data.begin() != data.end() ) {
+		metrics->sendtToKvalobs(1);
+	} else {
+		LOGWARN("Sending data to kvalobs: (no data to send)");
+		metrics->sendtToKvalobs(-1);
+	}
+	
 	metrics->kvDb.start();
 	kvalobs::serialize::KvalobsData toSend;
 	toSend.insert(data.begin(), data.end());

--- a/src/proxy/KvalobsDataAccess.cpp
+++ b/src/proxy/KvalobsDataAccess.cpp
@@ -93,7 +93,7 @@ void KvalobsDataAccess::getAllData(KvDataList & data, const boost::posix_time::p
 
     proxy::internal::KvDataReceiver dr( data );
     if ( ! KvApp::kvApp ) {
-			metrics->cacheDb.stop(true);
+			metrics->kvDb.stop(true);
     	throw std::runtime_error("kvApp not initialized");
 }
 

--- a/src/proxy/kvAgregated.mk
+++ b/src/proxy/kvAgregated.mk
@@ -15,4 +15,5 @@ kvAgregated_SOURCES += \
 	src/proxy/CallbackCollection.cpp \
 	src/proxy/ProxyDatabaseConnection.h \
 	src/proxy/ProxyDatabaseConnection.cpp \
-	src/proxy/ReadWriteLock.h
+	src/proxy/ReadWriteLock.h 
+


### PR DESCRIPTION
I have implemented some metrics for the aggregator. The metrics collected at the moment is total duration of cachedb access, duration of sending to kvalobs and total duration of running computation triged by a single observation.

It also logged if an observation has generated one or more aggregated values that is sendt to kvalobs.

The metric is written to the file /var/log/kvalobs/kvAgregated_metrics.log. 

The aggregator is running on the kvalobs staging host.